### PR TITLE
Easing is always done with interpolation

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,10 +67,6 @@ Keyframes.prototype.value = function(time, ease) {
     var endFrame = this.frames[ v[1] ]
     var t = v[2]
     
-    //frames are the same, don't bother easing
-    if (startFrame === endFrame)
-        return startFrame.value
-
     //We ease from left keyframe to right, with a custom easing
     //equation if specified
     if (typeof ease === 'function')


### PR DESCRIPTION
There is a benefit from not calling the ease method however if you want to use the ease method to lets say modify the value you'll have divergent behaviour based on what keyframe you're hitting.

For example:

``` javascript
var prevValue = null;

key.value( 0, function( start, end, t ) {

    if( start.value != prevValue ) {

        prevValue = start.value;

        return start.value;
    } else {

        return null;
    }
});
```
